### PR TITLE
replace sleep interval calculation with more correct one

### DIFF
--- a/history_daemon.py
+++ b/history_daemon.py
@@ -30,8 +30,6 @@ write_log('script started', 'LOG')
 
 
 while True:
-    start_time = int(time.time())
-
     ticker_url = ba.server.API_INDEX_URL+'all'
     try:
         current_data_all = requests.get(ticker_url, headers=ba.config.API_REQUEST_HEADERS).json()
@@ -62,9 +60,11 @@ while True:
     with open(general_default_file_path, 'wb') as default_file:
         default_file.write(json.dumps(actual_currency_links_list, indent=2, sort_keys=True, separators=(',', ': ')))
 
-    timestamp = email.utils.formatdate(time.time())
-    cycle_time = int(time.time())-start_time
-    sleep_time = max(0, HISTORY_QUERY_FREQUENCY-cycle_time)
+    current_time = time.time()
+    timestamp = email.utils.formatdate(current_time)
+    # Note that python's modulus operator handles floating point values
+    sleep_time = HISTORY_QUERY_FREQUENCY - (current_time % HISTORY_QUERY_FREQUENCY)
+    sleep_time = min(HISTORY_QUERY_FREQUENCY, sleep_time)
 
     print '%s, sleeping %ss - history daemon' % (timestamp, str(sleep_time))
 


### PR DESCRIPTION
The old timing routine will fall further behind the intended schedule by a fraction of a second on every iteration because it does not account for the time between that passes between the calculation of start_time and cycle_time. This new calculation should solve that problem.
