### PR TITLE
Hide slogan on small screens

### DIFF
--- a/www/index.htm
+++ b/www/index.htm
@@ -39,7 +39,7 @@
                     <meta itemprop="image" content="https://bitcoinaverage.com/img/logo_full_large.png" />
                     <meta itemprop="logo" content="https://bitcoinaverage.com/img/logo_full_large.png" />
                     <a class="navbar-brand logo" href="https://bitcoinaverage.com/" itemprop="url"><span itemprop="name">BitcoinAverage</span></a>
-                    <h1 class="navbar-brand slogan" itemprop="description">independent bitcoin price</h1>
+                    <h1 class="navbar-brand slogan hidden-xs" itemprop="description">independent bitcoin price</h1>
                 </div>
             </div>
             <div class="navbar-collapse collapse">


### PR DESCRIPTION
There are a few things that make this site look not so great on small smartphone screens. Most importantly, the slogan overflows and makes the navbar twice as high, covering up way too much of the screen. Resize your browser window to really skinny to see.

This pull request simply hides the slogan on small ("xs" in Bootstrap) screens.
