### PR TITLE
Update the BitX API parser to conform to the latest BitX API spec.

### DIFF
--- a/bitcoinaverage/config.py
+++ b/bitcoinaverage/config.py
@@ -147,7 +147,7 @@ EXCHANGE_LIST = {
                                  'bitcoincharts_symbols': {'BRL': 'mrcdBRL',
                                                            },
                                     },
-                    'bitx':  {'ticker_url': 'https://bitx.co.za/api/1/BTCZAR/ticker',
+                    'bitx':  {'ticker_url': 'https://bitx.co.za/api/1/ticker?pair=XBTZAR',
                               'display_name': 'BitX',
                                   },
                     'justcoin':  {'ticker_url': 'https://justcoin.com/api/v1/markets',


### PR DESCRIPTION
Hi

The BitX API spec has recently been updated to take a currency pair argument for the ticker call. (The old format still works but is deprecated.)

Regards,
Timothy
