### PR TITLE
Divide Coinfloor values by float to make returned values decimals.

### DIFF
--- a/bitcoinaverage/api_parsers.py
+++ b/bitcoinaverage/api_parsers.py
@@ -1157,9 +1157,9 @@ def _coinfloorApiCall(ticker_url, *args, **kwargs):
         ticker = json.loads(response)
 
         result = {}
-        result['GBP'] = {'ask': Decimal(ticker[0]['ask']/100).quantize(DEC_PLACES),
-                         'bid': Decimal(ticker[0]['bid']/100).quantize(DEC_PLACES),
-                         'last': Decimal(ticker[0]['last']/100).quantize(DEC_PLACES),
-                         'volume': Decimal(ticker[0]['volume']/10000).quantize(DEC_PLACES),
+        result['GBP'] = {'ask': Decimal(ticker[0]['ask']/100.0).quantize(DEC_PLACES),
+                         'bid': Decimal(ticker[0]['bid']/100.0).quantize(DEC_PLACES),
+                         'last': Decimal(ticker[0]['last']/100.0).quantize(DEC_PLACES),
+                         'volume': Decimal(ticker[0]['volume']/10000.0).quantize(DEC_PLACES),
                          }
         return result


### PR DESCRIPTION
I have looked at the code to determine why our ticker values are showing as integers and not decimals.  I am guessing that a potential reason is that the numbers are being divided by an integer.  I am proposing changing these to decimal numbers and thereby cause the division to be a decimal division.
