### PR TITLE
Urls taken from config instead of hardcoded

### DIFF
--- a/image_daemon.py
+++ b/image_daemon.py
@@ -5,7 +5,7 @@ import sys
 import requests
 import time
 from PIL import Image, ImageDraw, ImageFont
-from bitcoinaverage.server import FONT_PATH, WWW_DOCUMENT_ROOT
+from bitcoinaverage.server import FONT_PATH, WWW_DOCUMENT_ROOT, API_INDEX_URL
 try:
     from cStringIO import StringIO
 except:
@@ -13,7 +13,7 @@ except:
 
 
 # config locations
-base_url = "https://api.bitcoinaverage.com/ticker/"
+base_url = API_INDEX_URL + "ticker/"
 base = WWW_DOCUMENT_ROOT + "/img/" + "logo_xsmall.png"
 font_loc = FONT_PATH + "arialbd.ttf"
 

--- a/monitor_daemon.py
+++ b/monitor_daemon.py
@@ -11,9 +11,10 @@ import csv
 import StringIO
 from email import Utils
 from bitcoinaverage.server import MONITOR_RECIPIENT_EMAIL, MONITOR_SENDER_EMAIL
+from bitcoinaverage.server import API_INDEX_URL, API_INDEX_URL_HISTORY
 
-ticker_URL = "http://api.bitcoinaverage.com/ticker/USD"
-history_URL = "http://api.bitcoinaverage.com/history/USD/per_minute_24h_sliding_window.csv"
+ticker_URL = API_INDEX_URL + "ticker/USD"
+history_URL = API_INDEX_URL_HISTORY + "USD/per_minute_24h_sliding_window.csv"
 
 # email body
 message = '''To: %s

--- a/twitter_daemon.py
+++ b/twitter_daemon.py
@@ -7,11 +7,12 @@ import twitter
 import simplejson
 import requests
 
+from bitcoinaverage.server import API_INDEX_URL
 from bitcoinaverage.twitter_config import api
 
 logger = logging.getLogger("twitter_daemon")
 
-URL = "https://api.bitcoinaverage.com/ticker/global/USD"
+URL = API_INDEX_URL + "ticker/global/USD"
 
 change = 0
 oldprice = 0


### PR DESCRIPTION
Urls are loaded from the configuration instead of being hardcoded.

Note the example values in `server.py.dist` use trailing slashes on the index urls, which must be retained by the user values. The use of trailing slashes in `server.py.dist` is inconsistent and may want revision in the future (eg `WWW_DOCUMENT_ROOT` vs `API_INDEX_URL`).
